### PR TITLE
feat: 뉴스 상세페이지 api 연결, 댓글 작성, 메인에서 상세 연결

### DIFF
--- a/tim_news_flutter/lib/api/api_news/news_get/news_detail.dart
+++ b/tim_news_flutter/lib/api/api_news/news_get/news_detail.dart
@@ -6,7 +6,6 @@ import '../../api_login/error/result.dart';
 import '../../api_login/error/custom_exception.dart';
 import '../../api_login/error/run_catching_Exception.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:tim_news_flutter/news/models/news_detail_model.dart';
 
 final newDetailServiceProvider = Provider<NewsDetailService>((ref) {
   final dio = ref.watch(dioProvider);
@@ -22,7 +21,7 @@ class NewsDetailService {
 
 
   // 뉴스 상세정보 조회
-  Future<Result<NewsDetail, CustomExceptions>> getNewsDetail(news_id) async {
+  Future<Result<Map<String, dynamic>, CustomExceptions>> getNewsDetail(news_id) async {
     return runCatchingExceptions(() async {
       final accessToken = await storage.readAccessToken();
 
@@ -33,8 +32,25 @@ class NewsDetailService {
         ),
       );
 
-      print(response.data);
       return response.data;
+    });
+  }
+
+  // 댓글 작성
+  Future<Result<void, CustomExceptions>> createComment(news_id, comment, parentId) async {
+    return runCatchingExceptions(() async {
+      final accessToken = await storage.readAccessToken();
+      final response = await dio.post(
+        'http://${dotenv.env['LOCAL_API_URL']}/news/${news_id}/reply',
+        options: Options(
+          headers: {'Authorization': 'Bearer $accessToken'},
+        ),
+        data: {
+          "content": comment,
+          "parentId": parentId
+        }
+      );
+      print(response);
     });
   }
 

--- a/tim_news_flutter/lib/api/mypage/mypageApi.dart
+++ b/tim_news_flutter/lib/api/mypage/mypageApi.dart
@@ -161,7 +161,6 @@ class MypageApiService {
         ),
       );
 
-      print(response.data);
       return response.data;
     });
   }

--- a/tim_news_flutter/lib/mypage/myPage_notification.dart
+++ b/tim_news_flutter/lib/mypage/myPage_notification.dart
@@ -79,7 +79,7 @@ class _MyPageNotificationState extends ConsumerState<MyPageNotification> {
               child: Align(
                 alignment: Alignment.centerLeft,
                 child: Text(
-                  '새로운 알림 n건',
+                  '새로운 알림 ${alarms?.length ?? 0}건',
                   style: TextStyle(
                       fontWeight: FontWeight.bold,
                       fontSize: 22
@@ -90,19 +90,21 @@ class _MyPageNotificationState extends ConsumerState<MyPageNotification> {
             Expanded(
               child: Padding(
                 padding: EdgeInsets.all(20),
-                child: ListView.separated(
-                  itemCount: 2,
-                  itemBuilder: (c, i) {
-                    return Notification(type: 'follow');
-                  },
-                  separatorBuilder: (context, index) {
-                    return Divider(
-                      height: 1,
-                      thickness: 1,
-                      color: Colors.grey[300],
-                    );
-                  },
-                ),
+                child:
+                  alarms?.length != 0
+                  ? ListView.separated(
+                      itemCount: 2,
+                      itemBuilder: (c, i) {
+                        return Notification(type: 'follow');
+                      },
+                      separatorBuilder: (context, index) {
+                        return Divider(
+                          height: 1,
+                          thickness: 1,
+                          color: Colors.grey[300],
+                        );
+                      },
+                  ) : Text('알림이 없습니다'),
               ),
             )
           ],

--- a/tim_news_flutter/lib/news/models/news_detail_model.dart
+++ b/tim_news_flutter/lib/news/models/news_detail_model.dart
@@ -1,4 +1,4 @@
-class NewsDetail {
+class NewsDetailType {
   final String title;
   final String content;
   final String createdAt;
@@ -6,7 +6,7 @@ class NewsDetail {
   final List<Comment> comments;
   final int likes;
 
-  NewsDetail({
+  NewsDetailType({
     required this.title,
     required this.content,
     required this.createdAt,
@@ -15,15 +15,34 @@ class NewsDetail {
     required this.likes,
   });
 
-  factory NewsDetail.fromJson(Map<String, dynamic> json) {
-    return NewsDetail(
-      title: json['title'] ?? '',
-      content: json['content'] ?? '',
-      createdAt: json['createdAt'] ?? '',
-      newsTime: json['newsTime'] ?? '',
-      comments: (json['comments'] as List<dynamic>?)
-          ?.map((commentJson) => Comment.fromJson(commentJson))
-          .toList() ?? [],
+  factory NewsDetailType.fromJson(Map<String, dynamic> json) {
+    // newsData가 존재하는지 확인
+    print(json['data'].keys.toList());
+    final newsData = json['data']['newsData'];
+    print(newsData.keys.toList());
+    final commentsData = json['data']['comments'] as List<dynamic>? ?? [];
+    print(commentsData);
+
+    if (newsData == null) {
+      // newsData가 없는 경우 기본값 제공
+      return NewsDetailType(
+        title: '',
+        content: '',
+        createdAt: '',
+        newsTime: '',
+        comments: [],
+        likes: 0,
+      );
+    }
+
+    return NewsDetailType(
+      title: newsData['title'] ?? '',
+      content: newsData['content'] ?? '',
+      createdAt: newsData['createdAt'] ?? '',
+      newsTime: newsData['newsTime'] ?? '',
+      comments: commentsData
+          .map((commentJson) => Comment.fromJson(commentJson))
+          .toList(),
       likes: json['likes'] ?? 0,
     );
   }
@@ -35,7 +54,7 @@ class Comment {
   final String content;
   final String createdAt;
   final CommentUser user;
-  final List<Comment> children;  // 재귀적 구조: Comment 안에 Comment 리스트가 있음
+  final List<Comment> children;
 
   Comment({
     required this.replyId,

--- a/tim_news_flutter/lib/news/news_main.dart
+++ b/tim_news_flutter/lib/news/news_main.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:tim_news_flutter/api/api_news/news_get/news_all.dart';
 import 'package:tim_news_flutter/common/topNavigator.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tim_news_flutter/news/news_detail.dart';
 
 import '../common/loading_page.dart';
 
@@ -45,28 +46,36 @@ class NewsContent extends StatelessWidget {
           itemCount: newsList.length,
           itemBuilder: (context, index) {
             final item = newsList[index];
-            return Container(
-              decoration: BoxDecoration(
-                color: Colors
-                    .primaries[Random().nextInt(Colors.primaries.length)]
-                    .withValues(alpha: 0.3),
-              ),
+            return GestureDetector(
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (context) => NewsDetail(newsKey: item['newsId'],)),
+                );
+              },
               child: Container(
-                padding: EdgeInsets.symmetric(vertical: 10, horizontal: 10),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    Text(
-                      style: TextStyle(
-                        fontWeight: FontWeight.w700,
-                        fontSize: 15,
+                decoration: BoxDecoration(
+                  color: Colors
+                      .primaries[Random().nextInt(Colors.primaries.length)]
+                      .withValues(alpha: 0.3),
+                ),
+                child: Container(
+                  padding: EdgeInsets.symmetric(vertical: 10, horizontal: 10),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      Text(
+                        style: TextStyle(
+                          fontWeight: FontWeight.w700,
+                          fontSize: 15,
+                        ),
+                        item['title'],
+                        maxLines: 3,
+                        overflow: TextOverflow.ellipsis,
                       ),
-                      item['title'],
-                      maxLines: 3,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
             );


### PR DESCRIPTION
## TODO
- [x] 뉴스 상세페이지 조회 API
- [x] 댓글 작성 처리
- [x] 뉴스 메인 페이지 -> 상세페이지로 이동
- [ ] 댓글 삭제 or 수정
- [ ] 좋아요 처리 (API 수정 필요)
- [ ] 알림 처리(데이터 넣을 필요있음...)