### PR TITLE
feat: 마이페이지 알림 처리, 뉴스 상세페이지 좋아요 처리

### DIFF
--- a/tim_news_flutter/lib/api/api_news/news_get/news_detail.dart
+++ b/tim_news_flutter/lib/api/api_news/news_get/news_detail.dart
@@ -54,4 +54,28 @@ class NewsDetailService {
     });
   }
 
+  // 좋아요처리
+  Future<Result<void, CustomExceptions>> toggleLike(news_id, liked) async {
+    return runCatchingExceptions(() async {
+      final accessToken = await storage.readAccessToken();
+      if (liked == true) {
+        await dio.delete(
+            'http://${dotenv.env['LOCAL_API_URL']}/news/${news_id}/likes',
+            options: Options(
+              headers: {'Authorization': 'Bearer $accessToken'},
+            ),
+            data: {}
+        );
+      } else {
+        await dio.post(
+            'http://${dotenv.env['LOCAL_API_URL']}/news/${news_id}/likes',
+            options: Options(
+              headers: {'Authorization': 'Bearer $accessToken'},
+            ),
+            data: {}
+        );
+      }
+    });
+  }
+
 }

--- a/tim_news_flutter/lib/api/mypage/mypageApi.dart
+++ b/tim_news_flutter/lib/api/mypage/mypageApi.dart
@@ -44,7 +44,7 @@ class MypageApiService {
       final accessToken = await storage.readAccessToken();
 
       final response = await dio.get(
-        'http://${dotenv.env['LOCAL_API_URL']}/notifications',
+        'http://${dotenv.env['LOCAL_API_URL']}/notifications/unread',
         options: Options(
           headers: {'Authorization': 'Bearer $accessToken'},
         ),
@@ -162,6 +162,46 @@ class MypageApiService {
       );
 
       return response.data;
+    });
+  }
+
+  // 친구 수락
+  Future<Result<void, CustomExceptions>> acceptFriend(userId) async {
+    return runCatchingExceptions(() async {
+      final accessToken = await storage.readAccessToken();
+      await dio.post(
+        'http://${dotenv.env['LOCAL_API_URL']}/friends/accept?requestId=${userId}',
+        options: Options(
+          headers: {'Authorization': 'Bearer $accessToken'},
+        ),
+      );
+    });
+  }
+
+  // 친구 거절
+  Future<Result<void, CustomExceptions>> rejectFriend(userId) async {
+    return runCatchingExceptions(() async {
+      final accessToken = await storage.readAccessToken();
+      await dio.post(
+        'http://${dotenv.env['LOCAL_API_URL']}/friends/reject?requestId=${userId}',
+        options: Options(
+          headers: {'Authorization': 'Bearer $accessToken'},
+        ),
+      );
+    });
+  }
+
+
+  // 알람 읽음 처리
+  Future<Result<void, CustomExceptions>> readAlarm(notificationId) async {
+    return runCatchingExceptions(() async {
+      final accessToken = await storage.readAccessToken();
+      await dio.post(
+        'http://${dotenv.env['LOCAL_API_URL']}/notifications/${notificationId}/read',
+        options: Options(
+          headers: {'Authorization': 'Bearer $accessToken'},
+        ),
+      );
     });
   }
 }

--- a/tim_news_flutter/lib/mypage/myPage.dart
+++ b/tim_news_flutter/lib/mypage/myPage.dart
@@ -11,8 +11,6 @@ import './../api/api_login/provider/provider.dart';
 import 'package:tim_news_flutter/api/api_login/login/authRepository.dart';
 
 
-// todo: 새로운 알림 리스트 조회 후, 데이터가 있으면 뱃지 달아주기
-
 class MypageMain extends ConsumerStatefulWidget {
   const MypageMain({super.key});
 
@@ -25,6 +23,7 @@ class _MypageMainState extends ConsumerState<MypageMain> {
   bool isLoading = true;
   String? error;
   String sortType = 'recent';
+  bool isAlarm = false;
   
   @override
   void initState() {
@@ -32,6 +31,7 @@ class _MypageMainState extends ConsumerState<MypageMain> {
     
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _fetchUserProfile();
+
     });
   }
 
@@ -44,15 +44,20 @@ class _MypageMainState extends ConsumerState<MypageMain> {
 
       final apiService = ref.read(mypageApiServiceProvider);
       final result = await apiService.getUserProfile(sortType);
-      await apiService.getAlarmList();
+      final alarmsResult = await apiService.getAlarmList();
 
       if (result.isSuccess) {
         final userInfo = UserInfo.fromJson(result.value);
-
         setState(() {
           userProfileData = userInfo;
           isLoading = false;
         });
+
+        if (alarmsResult.isSuccess){
+          setState(() {
+            isAlarm = alarmsResult.value.length != 0 ? true : false;
+          });
+        }
 
         print("프로필 데이터: "
             "${userInfo.user.nickname} "
@@ -130,7 +135,7 @@ class _MypageMainState extends ConsumerState<MypageMain> {
         centerTitle: true,
         actions: [
           IconButton(
-            icon: Icon(Icons.notifications_outlined, color: Colors.black),
+            icon: Icon(isAlarm == true ? Icons.notifications_active_outlined : Icons.notifications_outlined, color: Colors.black),
             onPressed: () {
               Navigator.push(
                 context,

--- a/tim_news_flutter/lib/mypage/myPage_friendsList.dart
+++ b/tim_news_flutter/lib/mypage/myPage_friendsList.dart
@@ -6,7 +6,7 @@ import 'package:tim_news_flutter/mypage/mypage_friendProfile.dart';
 import './mypage_class.dart';
 
 // todo: 친구 있을 때 테스트 다시 해봐야 함
-// check: 프로필 이미지 없으면 어떻게 나오는지
+
 class MypageFriendList extends ConsumerStatefulWidget {
   const MypageFriendList({super.key, this.userName, this.friendCount});
   final userName;

--- a/tim_news_flutter/lib/mypage/myPage_newFriend.dart
+++ b/tim_news_flutter/lib/mypage/myPage_newFriend.dart
@@ -3,7 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tim_news_flutter/api/mypage/mypageApi.dart';
 import './mypage_class.dart';
 
-// todo: 로딩중 보여주기, 친추 완료하면 팝업 띄우기
+// todo: 친추 완료하면 팝업 띄우기
+
 class MypageNewFriend extends ConsumerStatefulWidget {
   const MypageNewFriend({super.key});
 

--- a/tim_news_flutter/lib/news/models/news_detail_model.dart
+++ b/tim_news_flutter/lib/news/models/news_detail_model.dart
@@ -5,6 +5,7 @@ class NewsDetailType {
   final String newsTime;
   final List<Comment> comments;
   final int likes;
+  final bool liked;
 
   NewsDetailType({
     required this.title,
@@ -13,37 +14,24 @@ class NewsDetailType {
     required this.newsTime,
     required this.comments,
     required this.likes,
+    required this.liked
   });
 
   factory NewsDetailType.fromJson(Map<String, dynamic> json) {
     // newsData가 존재하는지 확인
     print(json['data'].keys.toList());
-    final newsData = json['data']['newsData'];
-    print(newsData.keys.toList());
     final commentsData = json['data']['comments'] as List<dynamic>? ?? [];
-    print(commentsData);
-
-    if (newsData == null) {
-      // newsData가 없는 경우 기본값 제공
-      return NewsDetailType(
-        title: '',
-        content: '',
-        createdAt: '',
-        newsTime: '',
-        comments: [],
-        likes: 0,
-      );
-    }
 
     return NewsDetailType(
-      title: newsData['title'] ?? '',
-      content: newsData['content'] ?? '',
-      createdAt: newsData['createdAt'] ?? '',
-      newsTime: newsData['newsTime'] ?? '',
+      title: json['data']['title'] ?? '',
+      content: json['data']['content'] ?? '',
+      createdAt: json['data']['createdAt'] ?? '',
+      newsTime: json['data']['newsTime'] ?? '',
       comments: commentsData
           .map((commentJson) => Comment.fromJson(commentJson))
           .toList(),
-      likes: json['likes'] ?? 0,
+      likes: json['data']['likes'] ?? 0,
+      liked: json['data']['liked'] ?? false
     );
   }
 }


### PR DESCRIPTION
## 마이페이지 알림 처리
- [x] 마이페이지 메인에서 안 읽은 알림 있으면 아이콘 처리
- [x] 알림에 따른 처리 -> 좋아요, 댓글은 글로 보내줌, 친구 신청은 POPUP으로 처리
- [ ] 친구 신청은 테스트 필요..(type이 맞는지..? 잘 되는건지?)

## 뉴스 상세페이지
- [x] 좋아요 눌러진 글 표시
- [x] 좋아요
- [ ] 좋아요 취소 -> 에러 처리 필요 